### PR TITLE
Changes to deployment.yml

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -159,4 +159,4 @@ jobs:
             docker compose down
             
             # Start Docker compose
-            docker compose up
+            docker compose -f compose.yml -f compose.prod.yml up

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -29,14 +29,15 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: docker-image-name
+          name: docker-artifacts
           path: |
             build/libs/*.jar
-            image_name.txt          
+            image_name.txt
+            compose.yml
+            compose.prod.yml
 
-  docker-image-upload:
+  docker-upload:
     needs: build-and-test
-
     runs-on: ubuntu-latest
 
     steps:
@@ -46,7 +47,7 @@ jobs:
       - name: Pull cached artifact
         uses: actions/download-artifact@v3
         with:
-          name: docker-image-name
+          name: docker-artifacts
 
       - name: Login to Docker
         uses: docker/login-action@v3
@@ -60,7 +61,7 @@ jobs:
       - name: Download Image Name File
         uses: actions/download-artifact@v3
         with:
-          name: docker-image-name
+          name: docker-artifacts
 
       - name: Set variable with docker image name
         run: |
@@ -89,15 +90,14 @@ jobs:
           build-args: JAR_FILE=${{ steps.SET_JAR_FILE.outputs.JAR_FILE }}
           context: .
 
-  deploy:
-    needs: docker-image-upload
-
+  pre-deploy:
+    needs: docker-upload
     runs-on: ubuntu-latest
     steps:
       - name: Pull Saved Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: docker-image-name
+          name: docker-artifacts
 
       - name: Set variable with docker image name
         run: |
@@ -105,7 +105,7 @@ jobs:
           echo "DOCKER_IMAGE_NAME=$content" >> $GITHUB_ENV
         shell: bash
 
-      - name: Deploy to existing Docker Compose
+      - name: Prepare environment data
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.DROPLET_HOST }}
@@ -114,9 +114,6 @@ jobs:
           script: |
             # Change to working directory
             cd riven_of_a_thousand_servers/
-            
-            # Login to Docker
-            docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
             
             # Setup .env file
             rm -f .env
@@ -135,10 +132,31 @@ jobs:
             echo "GRAFANA_ADMIN_USERNAME=${{ secrets.GRAFANA_ADMIN_USERNAME }}" >> .env
             echo "GRAFANA_ADMIN_PASSWORD=${{ secrets.GRAFANA_ADMIN_PASSWORD }}" >> .env
             
+            # Change permissions on .env file
             chmod 600 .env
 
-            # Stop current Docker Compose
+      - name: Prepare Docker artifacts
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DROPLET_HOST }}
+          username: ${{ secrets.DROPLET_USERNAME }}
+          key: ${{ secrets.DROPLET_PRIVATE_TOKEN }}
+          source: "compose.yml,compose.prod.yml"
+          target: ./riven_of_a_thousand_servers/
+
+  deploy:
+    needs: pre-deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare environment data
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.DROPLET_HOST }}
+          username: ${{ secrets.DROPLET_USERNAME }}
+          key: ${{ secrets.DROPLET_PRIVATE_TOKEN }}
+          script: |
+            # Stop current Docker compose
             docker compose down
             
-            # Start Docker Compose
-            docker compose up -d
+            # Start Docker compose
+            docker compose up

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build/
+grafana/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,0 +1,4 @@
+services:
+  grafana:
+    environment:
+      GF_SERVER_ROOT_URL: "%(protocol)s://%(domain)s:%(http_port)s/grafana/"

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,5 @@
 services:
-  riven-of-a-thousand-servers:
+  rivenbot:
     container_name: rivenbot
     image: ${DOCKER_IMAGE_NAME}
     env_file:
@@ -43,6 +43,8 @@ services:
     container_name: loki
     hostname: loki
     image: grafana/loki:2.9.0
+    depends_on:
+      - rivenbot
     ports:
       - "3100:3100"
   grafana:
@@ -50,24 +52,6 @@ services:
     environment:
       GF_SECURITY_ADMIN_USER__FILE: /run/secrets/grafana_admin_username
       GF_SECURITY_ADMIN_PASSWORD__FILE: /run/secrets/grafana_admin_password
-    entrypoint:
-      - sh
-      - -euc
-      - |
-        mkdir -p /etc/grafana/provisioning/datasources
-        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
-        datasources:
-        - name: Loki
-          type: loki
-          access: proxy
-          orgId: 1
-          url: http://loki:3100
-          basicAuth: false
-          isDefault: true
-          version: 1
-          editable: false
-        EOF
-        /run.sh
     image: grafana/grafana-oss:latest
     ports:
       - "3000:3000"
@@ -75,7 +59,9 @@ services:
       - "grafana_admin_username"
       - "grafana_admin_password"
     volumes:
+      - ./grafana/custom-config.ini:/etc/grafana/grafana.ini
       - grafana-storage:/var/lib/grafana
+      - ./grafana/ds.yaml:/etc/grafana/provisioning/datasources/ds.yaml
 
 secrets:
   mongo_username:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
       authentication-database: admin
       database: riven_of_a_thousand_servers
       port: 27017
+  main:
+    banner-mode: log
 
 bungie:
   api:


### PR DESCRIPTION
This PR has no issue attached but these are some minor changes to the deployment.yml workflow. First, the deploy stage was split into `pre-deploy` and `deploy` stages. The `pre-deploy` stage sets up all the environment information necessary for all Docker containers to run correctly in a `.env` file as well as putting the necessary `compose.yml` and `compose.prod.yml` files in the working directory for the RivenBot in DigitalOcean. And lastly, the `deploy` stage runs the Docker commands to run the containers using Docker Compose.